### PR TITLE
Fixes for push notification when in killed state

### DIFF
--- a/cordova-plugin-hms-push/src/main/java/com/huawei/hms/cordova/push/remote/HmsPushMessageService.java
+++ b/cordova-plugin-hms-push/src/main/java/com/huawei/hms/cordova/push/remote/HmsPushMessageService.java
@@ -68,6 +68,7 @@ public class HmsPushMessageService extends HmsMessageService {
                 String preFunction = sharedPref.getString("data", null);
                 if (preFunction != null) {
                     preFunction = preFunction.replace("=>", "");
+                    preFunction = preFunction.replace("function", "");
                 }
                 String function = String.format(Locale.ENGLISH, "function callback%s", preFunction);
                 String s = "[\"HmsLocalNotification\"].backgroundLocalNotification";


### PR DESCRIPTION
Not able to receive push notification when app is in killed state. I noticed the evaluateJavascript parameter is incorrect.

```
this.hmsPush
      .setBackgroundAction((remoteMessage) => {
        const jsonData = JSON.parse(remoteMessage.data);
        const defaultNotification = {
          title: jsonData.title,
          message: jsonData.body,
        };
        const notification = JSON.stringify(defaultNotification);
        HmsLocalNotification.backgroundLocalNotification(notification);
      })
      .then((result) => console.log("setBackgroundAction", result))
      .catch((error) => console.log("setBackgroundAction", error));
  }
```

Here's the log before and after the fix.
**Before**
https://ghostbin.co/paste/ee3geqa

**After**
https://ghostbin.co/paste/o4vx

**Environment**
Platform: Ionic Cordova
Kit: Push
Kit Version 5.0.2-301
Platform version 4.11.10
angular/core - 8.1.2
ionic/angular - 4.11.10
Node Version 10.17
Cordova CLI - 10.0.0