### PR TITLE
UPDATE cordova-plugin-hms-push 6.7.0-300

### DIFF
--- a/cordova-plugin-hms-push/example/cordova/config.xml
+++ b/cordova-plugin-hms-push/example/cordova/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget id="<PACKAGE_NAME>" version="6.3.0.304" xmlns="http://www.w3.org/ns/widgets">
+<widget id="<PACKAGE_NAME>" version="6.7.0.300" xmlns="http://www.w3.org/ns/widgets">
 	<name>
 		CordovaHMSPushDemo
 	</name>

--- a/cordova-plugin-hms-push/example/cordova/package.json
+++ b/cordova-plugin-hms-push/example/cordova/package.json
@@ -1,7 +1,7 @@
 {
   "name": "CordovaHMSPushDemo",
   "displayName": "CordovaHMSPushDemo",
-  "version": "6.3.0-304",
+  "version": "6.7.0-300",
   "description": "A demo application which shows the usage of HMS Push SDK",
   "main": "index.js",
   "scripts": {

--- a/cordova-plugin-hms-push/example/ionic/package.json
+++ b/cordova-plugin-hms-push/example/ionic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "HMSPushDemo",
-  "version": "6.3.0-304",
+  "version": "6.7.0-300",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/cordova-plugin-hms-push/ionic-native/dist/ngx/package.json
+++ b/cordova-plugin-hms-push/ionic-native/dist/ngx/package.json
@@ -1,8 +1,8 @@
 {
     "name": "@hmscore/ionic-native-hms-push",
     "description": "Ionic Native wrappers for Cordova Plugin HMS Push",
-    "version": "6.3.0-304",
-    "zipVersion": "6.3.0.304",
+    "version": "6.7.0-300",
+    "zipVersion": "6.7.0.300",
     "module": "index.js",
     "typings": "index.d.ts",
     "license": "Apache-2.0",

--- a/cordova-plugin-hms-push/ionic-native/dist/package.json
+++ b/cordova-plugin-hms-push/ionic-native/dist/package.json
@@ -1,8 +1,8 @@
 {
     "name": "@hmscore/ionic-native-hms-push",
     "description": "Ionic Native wrappers for Cordova Plugin HMS Push",
-    "version": "6.3.0-304",
-    "zipVersion": "6.3.0.304",
+    "version": "6.7.0-300",
+    "zipVersion": "6.7.0.300",
     "module": "index.js",
     "typings": "index.d.ts",
     "license": "Apache-2.0",

--- a/cordova-plugin-hms-push/package.json
+++ b/cordova-plugin-hms-push/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@hmscore/cordova-plugin-hms-push",
     "description": "Cordova HMS Push Plugin",
-    "version": "6.3.0-304",
+    "version": "6.7.0-300",
     "main": "./www/HmsPush.js",
     "types": "./types/index.d.ts",
     "repository": {

--- a/cordova-plugin-hms-push/plugin.xml
+++ b/cordova-plugin-hms-push/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-plugin-hms-push"
-	version="6.3.0-304"
+	version="6.7.0-300"
 	xmlns="http://apache.org/cordova/ns/plugins/1.0">
 	<name>
 		Cordova Plugin HMS Push
@@ -53,9 +53,11 @@
 		</config-file>
 		<config-file target="AndroidManifest.xml" parent="application">
 			<receiver
-				android:name="com.huawei.hms.cordova.push.receiver.HmsLocalNotificationActionsReceiver" />
+				android:name="com.huawei.hms.cordova.push.receiver.HmsLocalNotificationActionsReceiver"
+				android:exported="false" />
 			<receiver
-				android:name="com.huawei.hms.cordova.push.receiver.HmsLocalNotificationBootEventReceiver">
+				android:name="com.huawei.hms.cordova.push.receiver.HmsLocalNotificationBootEventReceiver"
+				android:exported="true">
 				<intent-filter>
 					<action android:name="android.intent.action.BOOT_COMPLETED" />
 				</intent-filter>
@@ -74,7 +76,7 @@
 		</config-file>
 		<framework src="androidx.core:core:1.3.1" />
 		<framework src="com.facebook.fresco:fresco:2.5.0" />
-		<framework src="com.huawei.hms:push:6.3.0.304" />
+		<framework src="com.huawei.hms:push:6.7.0.300" />
 		<framework src="src/android/build-extras.gradle" custom="true"
 			type="gradleReference"></framework>
 		<source-file src="src/android/src/main/java/com/huawei/hms/cordova/push/HMSPush.java"

--- a/cordova-plugin-hms-push/src/android/src/main/java/com/huawei/hms/cordova/push/HMSPush.java
+++ b/cordova-plugin-hms-push/src/android/src/main/java/com/huawei/hms/cordova/push/HMSPush.java
@@ -49,7 +49,7 @@ public class HMSPush extends CordovaPlugin {
 
     private static final String KIT = "Push";
 
-    private static final String VERSION = "6.3.0.304";
+    private static final String VERSION = "6.7.0.300";
 
     private static CordovaInterface staticCordova;
 


### PR DESCRIPTION
Hi everyone!

I updated the `cordova-plugin-hms-push` package to use the most recent version of the HMS Push Kit SDK ([6.7.0-300](https://developer.huawei.com/consumer/en/doc/development/HMSCore-Guides/android-app-version-0000001074227861#section16497104717716)).
I also added a missing `android:exported` attribute to some `<receiver>` tags in the `plugin.xml` file to ensure Android 12 compatibility (more on the attribute usage [here](https://developer.android.com/guide/topics/manifest/receiver-element#exported)).

If the attribute is not correctly declared, the following error appears:

>Manifest merger failed : android:exported needs to be explicitly specified for <receiver>. Apps targeting Android 12 and higher are required to specify an explicit value for `android:exported` when the corresponding component has an intent filter defined. See [Android docs](https://developer.android.com/guide/topics/manifest/receiver-element#exported) for details.